### PR TITLE
chore/add release workflow

### DIFF
--- a/.changeset/thin-gorillas-fetch.md
+++ b/.changeset/thin-gorillas-fetch.md
@@ -1,0 +1,5 @@
+---
+'@equinor/apollo-components': patch
+---
+
+Expose capitalizeHeader utility to trigger a changeset

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -1,0 +1,30 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_lint:
+    name: 🚧 Build, Lint and Test Project
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'yarn'
+
+      - name: 📦 Install Dependencies
+        run: yarn install --frozen-lockfile --prefer-offline
+
+      - name: 👷 Build app to check for build time errors
+        run: yarn build
+
+      - name: 💄 Lint code
+        run: yarn lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: 📦️ Install Dependencies
         run: yarn
 
-      - name: 🚀 Create Release Pull Request or Publish to npm
+      - name: 🦋 Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+
+      - name: Install Dependencies
+        run: yarn
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # This expects you to have a script called release which does a build for your packages and calls changeset publish
+          publish: yarn release-packages
+          title: 🚀 Release Apollo Components
+          commit: 🔖 Create changeset for release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,17 @@ jobs:
         with:
           node-version: 16.x
 
-      - name: Install Dependencies
+      - name: 📦️ Install Dependencies
         run: yarn
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: 🚀 Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn release-packages
           title: 🚀 Release Apollo Components
-          commit: 🔖 Create changeset for release
+          commit: 🔖 Create changesets for release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ To use the local dev package version in other projects, make point to the local 
 -  "@equinor/apollo-components": "^1.5.0",
 ```
 
+### Publish
+
+Packages are published through the CI system using [Changesets](https://github.com/changesets/changesets). A changeset contains a description of changes for each package, as well as the semantic version in crease (major.minor.patch).
+
+When changesets are merged into main, a PR is created to publish the NPM packages and update the changelog.
+
+An NPM_TOKEN is required to publish packages to the registry, and is tied to a specific user.
+To setup NPM publishing do the following:
+
+1. Apply to be a member of the @Equinor organization on NPM.
+2. Create an Access Token. It should be "Classic Token with Publish permissions.
+3. Copy the token as a repository secret.
+
 ## Useful Links
 
 Learn more about the power of Turborepo:

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "postinstall": "husky install",
     "lint": "turbo run lint",
     "publish-packages": "turbo run build lint && changeset version && changeset publish",
+    "release-packages": "turbo run build && changeset publish",
     "storybook": "cd packages/apollo-components && yarn storybook"
   },
   "lint-staged": {

--- a/packages/apollo-components/src/DataTable/index.ts
+++ b/packages/apollo-components/src/DataTable/index.ts
@@ -11,5 +11,5 @@ DataTable.Provider = DataTableProvider
 export { globalFilterAtom, rowSelectionAtom, tableSortingAtom } from './atoms'
 export * from './components'
 export * from './types'
-export { prependSelectColumn } from './utils'
+export { capitalizeHeader, prependSelectColumn } from './utils'
 export { DataTable }


### PR DESCRIPTION
## What does this pull request change?
- 📝 Add section in README about publishing
- 👷 Add release workflow for publishing apollo components
- 👷 Add pull request CI workflow
- 🔖 Create changeset for automatic publishing testing

## Why is this pull request needed?
The current publishing procedure is done from a developer machine and is not ideal for cooperation.

## Issues related to this change:
[AB#313468](https://dev.azure.com/Equinor/5f972ff3-ed9a-4405-9db1-84542b5007a8/_workitems/edit/313468)
