### PR TITLE
✨ Add cell highlight configuration

### DIFF
--- a/.changeset/ninety-shrimps-enjoy.md
+++ b/.changeset/ninety-shrimps-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@equinor/apollo-components': minor
+---
+
+Add cell highlight configuration and fix row background not being set

--- a/apps/playground/src/components/PokemonTable/PokemonTable.tsx
+++ b/apps/playground/src/components/PokemonTable/PokemonTable.tsx
@@ -1,10 +1,6 @@
 import { DataTable } from '@equinor/apollo-components'
-import { Pokemon, pokemon } from '../../data'
+import { pokemon } from '../../data'
 import { pokemonColumns } from './columns'
-
-type PokemonNode = Pokemon & {
-  children?: Pokemon[]
-}
 
 export const PokemonTable = () => {
   return (
@@ -18,7 +14,6 @@ export const PokemonTable = () => {
             height: '500px',
             rowSelectionMode: 'single',
             selectColumn: 'default',
-            getSubRows: (row) => (row as PokemonNode).children,
             getRowId: (row) => row.id.toString(),
           }}
           data={pokemon}
@@ -27,10 +22,15 @@ export const PokemonTable = () => {
             columnSelect: true,
           }}
           header={{ stickyHeader: true, tableCaption: 'Pokédex' }}
+          cellConfig={{
+            getShouldHighlight(cell) {
+              return cell.column.id === 'name' && cell.row.original.type.includes('Water')
+            },
+          }}
           rowConfig={{
             onClick: (row) => row.toggleSelected(),
-            onMouseEnter: (row) => {
-              console.log({ rowId: row.original.id })
+            getRowBackground(row) {
+              return row.original.type.includes('Poison') ? '#e0febd' : undefined
             },
           }}
         />

--- a/packages/apollo-components/src/DataTable/DataTable.tsx
+++ b/packages/apollo-components/src/DataTable/DataTable.tsx
@@ -58,6 +58,7 @@ export function DataTable<T>({
   header,
   filters,
   config,
+  cellConfig,
   rowConfig,
 }: DataTableProps<T>) {
   const [columnVisibility, setColumnVisibility] = useAtom(columnVisibilityAtom)
@@ -129,6 +130,7 @@ export function DataTable<T>({
             containerRef={tableContainerRef}
             table={table}
             rowConfig={rowConfig}
+            cellConfig={cellConfig}
             isLoading={isLoading}
             stickyHeader={header?.stickyHeader}
           />
@@ -136,6 +138,7 @@ export function DataTable<T>({
           <BasicTable
             table={table}
             rowConfig={rowConfig}
+            cellConfig={cellConfig}
             isLoading={isLoading}
             stickyHeader={header?.stickyHeader}
           />

--- a/packages/apollo-components/src/DataTable/components/TableRow.tsx
+++ b/packages/apollo-components/src/DataTable/components/TableRow.tsx
@@ -15,7 +15,10 @@ export function TableRow<T>({ row, rowConfig, cellConfig }: TableRowProps<T>) {
   const tableRowContent = (
     <Table.Row
       active={row.getIsSelected()}
-      style={{ cursor: rowConfig?.onClick ? 'pointer' : 'initial' }}
+      style={{
+        cursor: rowConfig?.onClick ? 'pointer' : 'initial',
+        backgroundColor: rowConfig?.getRowBackground?.(row),
+      }}
       onClick={() => rowConfig?.onClick?.(row)}
       onMouseEnter={handleRowEvent(row, rowConfig?.onMouseEnter)}
       onMouseLeave={handleRowEvent(row, rowConfig?.onMouseLeave)}
@@ -25,6 +28,7 @@ export function TableRow<T>({ row, rowConfig, cellConfig }: TableRowProps<T>) {
           cell={cell}
           key={cell.id}
           getStickyCellColor={cellConfig?.getStickyCellColor}
+          highlight={cellConfig?.getShouldHighlight?.(cell)}
         />
       ))}
     </Table.Row>

--- a/packages/apollo-components/src/DataTable/types.ts
+++ b/packages/apollo-components/src/DataTable/types.ts
@@ -37,6 +37,7 @@ export interface RowConfig<T> {
 
 export interface CellConfig<T> {
   getStickyCellColor?: (cell: Cell<T, unknown>) => string
+  getShouldHighlight?: (cell: Cell<T, unknown>) => boolean
 }
 
 export type RowSelectionMode = 'single' | 'multiple'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7584,11 +7584,6 @@ jotai@^1.10.0:
   resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.10.0.tgz#50c5224789282eca1cdc907a51e316d8d94c5976"
   integrity sha512-3Q8kQU3Ktds+80Ku4dVcvnwSXEcK0Fg0b6mC1+4wz3rmF64lOGNUySKXQ4njvYCWodR8bw2HygOKYSYkHxQQmA==
 
-jotai@^1.13.1:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/jotai/-/jotai-1.13.1.tgz#20cc46454cbb39096b12fddfa635b873b3668236"
-  integrity sha512-RUmH1S4vLsG3V6fbGlKzGJnLrDcC/HNb5gH2AeA9DzuJknoVxSGvvg8OBB7lke+gDc4oXmdVsaKn/xDUhWZ0vw==
-
 joycon@^3.0.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"


### PR DESCRIPTION
## What does this pull request change?
Add `getShouldHighlight` function to CellConfig that takes a generic `Cell<T, unknown>`.
Fix `getRowBackground` not being called and used in `TableRow` component. 

## Why is this pull request needed?
Primarily a Plant Tracker need, the highlight needs to be set on a per-cell and row basis. 
The row background was not set properly.

## Issues related to this change:
[AB#315121](https://dev.azure.com/Equinor/5f972ff3-ed9a-4405-9db1-84542b5007a8/_workitems/edit/315121)
