### PR TITLE
🚸 Make indeterminate checkbox deselect all rows

### DIFF
--- a/.changeset/dry-rabbits-cross.md
+++ b/.changeset/dry-rabbits-cross.md
@@ -1,0 +1,5 @@
+---
+'@equinor/apollo-components': patch
+---
+
+Make select column indeterminate state deselect all rows

--- a/packages/apollo-components/src/cells/SelectColumnDef.tsx
+++ b/packages/apollo-components/src/cells/SelectColumnDef.tsx
@@ -27,7 +27,11 @@ export function SelectColumnDef<T>(props: DataTableConfig<T> = {}): ColumnDef<T,
             checked={table.getIsAllRowsSelected()}
             indeterminate={table.getIsSomeRowsSelected()}
             aria-label={table.getIsAllRowsSelected() ? 'Deselect all rows' : 'Select all rows'}
-            onChange={table.getToggleAllRowsSelectedHandler()}
+            onChange={
+              table.getIsSomeRowsSelected()
+                ? () => table.toggleAllRowsSelected(false)
+                : table.getToggleAllRowsSelectedHandler()
+            }
           />
         </CellWrapper>
       ) : null,


### PR DESCRIPTION
## What does this pull request change?
When header checkbox for the default `SelectColumnDef` is in an indeterminate state, deselect all columns on click.

## Why is this pull request needed?
The indeterminate checkbox state in the header was confusing, as clicking the checkbox with ➖ selected all columns, instead of deselecting.
## Issues related to this change:
[AB#328016](https://dev.azure.com/Equinor/5f972ff3-ed9a-4405-9db1-84542b5007a8/_workitems/edit/328016)