### PR TITLE
✨ Enable manual sorting and deprecate config.sorable naming

### DIFF
--- a/.changeset/little-apes-hunt.md
+++ b/.changeset/little-apes-hunt.md
@@ -1,0 +1,7 @@
+---
+'jotai-form-example': minor
+'playground': minor
+'@equinor/apollo-components': minor
+---
+
+Expose onSortingChange and enable custom sorting and deprecate `sortable` and move config to `sortConfig.enableSorting`.

--- a/apps/jotai-form-example/src/features/pokemon-page/PokemonTable.tsx
+++ b/apps/jotai-form-example/src/features/pokemon-page/PokemonTable.tsx
@@ -15,10 +15,10 @@ export function PokemonTable() {
           virtual: true,
           tableLayout: 'fixed', // Required for using columns with fixed width
           height: '80vh',
-          sortable: true,
           selectColumn: 'default',
           getRowId: (row) => row.id.toString(),
         }}
+        sortConfig={{ enableSorting: true }}
         header={{ stickyHeader: true }}
         filters={{ globalFilter: true, columnSelect: true }}
       />

--- a/apps/jotai-form-example/src/features/unit-events-page/UnitEventsTable.tsx
+++ b/apps/jotai-form-example/src/features/unit-events-page/UnitEventsTable.tsx
@@ -15,10 +15,10 @@ export function UnitEventsTable() {
           virtual: true,
           tableLayout: 'fixed', // Required for using columns with fixed width
           height: '80vh',
-          sortable: true,
           selectColumn: 'default',
           getRowId: (row) => row.id.toString(),
         }}
+        sortConfig={{ enableSorting: true }}
         header={{ stickyHeader: true }}
         filters={{ globalFilter: true, columnSelect: true }}
       />

--- a/apps/playground/src/components/PokemonTable/PokemonTable.tsx
+++ b/apps/playground/src/components/PokemonTable/PokemonTable.tsx
@@ -9,7 +9,6 @@ export const PokemonTable = () => {
         <DataTable
           columns={pokemonColumns}
           config={{
-            sortable: true,
             virtual: true,
             height: '500px',
             rowSelectionMode: 'single',
@@ -21,6 +20,7 @@ export const PokemonTable = () => {
             globalFilter: true,
             columnSelect: true,
           }}
+          sortConfig={{ enableSorting: true }}
           header={{ stickyHeader: true, tableCaption: 'Pokédex' }}
           cellConfig={{
             getShouldHighlight(cell) {

--- a/packages/apollo-components/src/DataTable/DataTable.stories.tsx
+++ b/packages/apollo-components/src/DataTable/DataTable.stories.tsx
@@ -13,9 +13,11 @@ export default {
   component: DataTable,
   args: {
     config: {
-      sortable: true,
       width: '100%',
       virtual: false,
+    },
+    sortConfig: {
+      enableSorting: true,
     },
     header: {
       captionPadding: '1rem',

--- a/packages/apollo-components/src/DataTable/DataTableRaw.stories.tsx
+++ b/packages/apollo-components/src/DataTable/DataTableRaw.stories.tsx
@@ -17,10 +17,12 @@ export default {
   component: DataTableRaw,
   args: {
     config: {
-      sortable: true,
       width: '100%',
       height: '100%',
       virtual: false,
+    },
+    sortConfig: {
+      enableSorting: true,
     },
     header: {
       captionPadding: '1rem',

--- a/packages/apollo-components/src/DataTable/types.ts
+++ b/packages/apollo-components/src/DataTable/types.ts
@@ -1,4 +1,4 @@
-import { Cell, ColumnDef, Row, Table } from '@tanstack/react-table'
+import { Cell, ColumnDef, OnChangeFn, Row, SortingState, Table } from '@tanstack/react-table'
 import { ReactElement, ReactNode } from 'react'
 
 export interface HeaderConfig {
@@ -37,6 +37,13 @@ export interface RowConfig<T> {
 
 export type TruncateMode = 'wrap' | 'hover'
 
+export type SortConfig = {
+  enableSorting?: boolean
+  manualSorting?: boolean
+  sorting?: SortingState
+  onSortingChange?: OnChangeFn<SortingState>
+}
+
 export interface CellConfig<T> {
   getStickyCellColor?: (cell: Cell<T, unknown>) => string
   getShouldHighlight?: (cell: Cell<T, unknown>) => boolean
@@ -64,6 +71,7 @@ export type DataTableConfig<T> = {
    * Default size is 150px.
    */
   tableLayout?: TableLayout
+  /** @deprecated use `cellConfig.enableSorting` instead. This is to align with \@tanstack/react-table types. */
   sortable?: boolean
   virtual?: boolean
   rowSelectionMode?: RowSelectionMode
@@ -84,6 +92,7 @@ export interface DataTableCommonProps<T> {
   config?: DataTableConfig<T>
   cellConfig?: CellConfig<T>
   rowConfig?: RowConfig<T>
+  sortConfig?: SortConfig
   filters?: FilterConfig
   header?: HeaderConfig
 }

--- a/packages/apollo-components/src/DataTable/useDataTable.tsx
+++ b/packages/apollo-components/src/DataTable/useDataTable.tsx
@@ -21,7 +21,7 @@ import { DataTableProps } from './types'
 import { enableOrUndefined, getFunctionValueOrDefault, prependSelectColumn } from './utils'
 
 export function useDataTable<T>(props: DataTableProps<T>): Table<T> {
-  const { columns, data, filters, config, cellConfig } = props
+  const { columns, data, filters, config, cellConfig, sortConfig } = props
   const [columnVisibility, setColumnVisibility] = useAtom(columnVisibilityAtom)
   const [globalFilter, setGlobalFilter] = useAtom(globalFilterAtom)
   const [sorting, setSorting] = useAtom(tableSortingAtom)
@@ -40,7 +40,8 @@ export function useDataTable<T>(props: DataTableProps<T>): Table<T> {
     state: {
       expanded,
       globalFilter: enableGlobalFilter(globalFilter),
-      sorting: enableOrUndefined(config?.sortable, sorting),
+      sorting:
+        sortConfig?.enableSorting || config?.sortable ? sortConfig?.sorting ?? sorting : undefined,
       rowSelection: rowSelectionState,
       columnVisibility,
     },
@@ -55,7 +56,8 @@ export function useDataTable<T>(props: DataTableProps<T>): Table<T> {
         )
       },
     },
-    enableSorting: config?.sortable,
+    enableSorting: sortConfig?.enableSorting ?? config?.sortable,
+    manualSorting: sortConfig?.manualSorting,
     enableExpanding: !config?.hideExpandControls,
     enableMultiRowSelection: config?.rowSelectionMode === 'multiple',
     enableSubRowSelection: config?.rowSelectionMode !== 'single',
@@ -66,7 +68,10 @@ export function useDataTable<T>(props: DataTableProps<T>): Table<T> {
     getSortedRowModel: getSortedRowModel(),
     onExpandedChange: setExpanded,
     onRowSelectionChange: setRowSelectionState,
-    onSortingChange: enableOrUndefined(config?.sortable, setSorting),
+    onSortingChange:
+      sortConfig?.enableSorting || config?.sortable
+        ? sortConfig?.onSortingChange ?? setSorting
+        : undefined,
     onColumnVisibilityChange: setColumnVisibility,
     onGlobalFilterChange: enableGlobalFilter(setGlobalFilter),
     getSubRows: config?.getSubRows,


### PR DESCRIPTION
## What does this pull request change?

- Deprecate `config.sortable` and introduce `sortConfig.enableSorting`.
- Expose `sorting`, `onSortingChange` and `manualSorting`.

## Why is this pull request needed?

- Enable custom sorting
- Align with react table types

## Issues related to this change:
[AB#330853](https://dev.azure.com/Equinor/5f972ff3-ed9a-4405-9db1-84542b5007a8/_workitems/edit/330853)
