### PR TITLE
🏷️ Re-export react-table types

### DIFF
--- a/.changeset/many-squids-dance.md
+++ b/.changeset/many-squids-dance.md
@@ -1,0 +1,5 @@
+---
+'@equinor/apollo-components': patch
+---
+
+Re-export from react-table

--- a/packages/apollo-components/package.json
+++ b/packages/apollo-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/apollo-components",
-  "version": "3.5.1",
+  "version": "3.5.1-beta.3",
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/apollo-components/src/DataTable/index.ts
+++ b/packages/apollo-components/src/DataTable/index.ts
@@ -1,4 +1,4 @@
 export * from './components'
-export { DataTable } from './DataTable'
+export * from './DataTable'
 export * from './types'
-export { capitalizeHeader, prependSelectColumn } from './utils'
+export * from './utils'

--- a/packages/apollo-components/src/DataTable/types.ts
+++ b/packages/apollo-components/src/DataTable/types.ts
@@ -1,8 +1,12 @@
-import {
+import type {
   Cell,
+  CellContext,
   ColumnDef,
   ColumnPinningState,
+  ColumnResizeMode,
+  ColumnSort,
   ExpandedState,
+  HeaderContext,
   OnChangeFn,
   Row,
   RowSelectionState,
@@ -10,8 +14,7 @@ import {
   Table,
   VisibilityState,
 } from '@tanstack/react-table'
-import { TableOptions } from '@tanstack/table-core/build/lib/types'
-import {
+import type {
   Dispatch,
   HTMLProps,
   MutableRefObject,
@@ -19,6 +22,24 @@ import {
   ReactNode,
   SetStateAction,
 } from 'react'
+
+// Re-exports from react-table
+export type {
+  Cell,
+  CellContext,
+  ColumnDef,
+  ColumnPinningState,
+  ColumnResizeMode,
+  ColumnSort,
+  ExpandedState,
+  HeaderContext,
+  OnChangeFn,
+  Row,
+  RowSelectionState,
+  SortingState,
+  Table,
+  VisibilityState,
+}
 
 export interface TableRowWrapper<T> {
   (props: TableRowWrapperProps<T>): ReactElement
@@ -100,7 +121,7 @@ export interface DataTableProps<T> {
   virtual?: boolean
   getRowId?: (originalRow: T, index: number, parent: Row<T> | undefined) => string
   getSubRows?: (originalRow: T) => T[] | undefined
-  columnResizing?: boolean | TableOptions<T>['columnResizeMode']
+  columnResizing?: boolean | ColumnResizeMode
   rowSelection?: Partial<ControlledState<RowSelectionState>> & {
     mode?: RowSelectionMode
     selectColumn?: 'default' | ((options?: Record<string, any>) => ColumnDef<T, any>)

--- a/packages/apollo-components/src/DataTable/utils.tsx
+++ b/packages/apollo-components/src/DataTable/utils.tsx
@@ -1,6 +1,9 @@
-import { Column, ColumnDef, HeaderContext } from '@tanstack/react-table'
+import { Column, ColumnDef, createColumnHelper, HeaderContext } from '@tanstack/react-table'
 import { SelectColumnDef } from '../cells'
 import { DataTableProps } from './types'
+
+// Re-exports from react-table
+export { createColumnHelper }
 
 /**
  * Capitalize the table header.


### PR DESCRIPTION
## What does this pull request change?

Re-export types.

## Why is this pull request needed?

Exporting types from apollo-components removes the need of adding @tanstack/react-table as an extra dependency for users.

## Issues related to this change:

[AB#389480](https://dev.azure.com/Equinor/5f972ff3-ed9a-4405-9db1-84542b5007a8/_workitems/edit/389480)