### PR TITLE
:sparkles: support column select button text

### DIFF
--- a/.changeset/lovely-starfishes-hope.md
+++ b/.changeset/lovely-starfishes-hope.md
@@ -1,0 +1,5 @@
+---
+'@equinor/apollo-components': minor
+---
+
+support select column button text

--- a/packages/apollo-components/.eslintrc.cjs
+++ b/packages/apollo-components/.eslintrc.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   root: true,
   extends: ['custom'],
+  ignorePatterns: ['node_modules', 'storybook-static']
 }

--- a/packages/apollo-components/src/DataTable/DataTable.stories.tsx
+++ b/packages/apollo-components/src/DataTable/DataTable.stories.tsx
@@ -26,6 +26,7 @@ const args: Partial<DataTableProps<unknown>> = {
 export default {
   title: 'DataTable/DataTable',
   component: DataTable,
+
   args,
   argTypes: {
     data: disableControl(),
@@ -46,6 +47,43 @@ export const GlobalFilter: ComponentStoryFn<typeof DataTable<Fruit>> = ({
     data={fruitsData}
     columns={fruitColumns}
     bannerConfig={{
+      enableGlobalFilterInput: filters?.enableGlobalFilterInput,
+      globalFilterPlaceholder: filters?.globalFilterPlaceholder?.length
+        ? filters.globalFilterPlaceholder
+        : 'Forage for fruit',
+    }}
+  />
+)
+
+export const ColumnSelect: ComponentStoryFn<typeof DataTable<Fruit>> = ({
+ bannerConfig: filters,
+ ...props
+}) => (
+  <DataTable
+    {...props}
+    data={fruitsData}
+    columns={fruitColumns}
+    bannerConfig={{
+      enableColumnSelect: true,
+      enableGlobalFilterInput: filters?.enableGlobalFilterInput,
+      globalFilterPlaceholder: filters?.globalFilterPlaceholder?.length
+        ? filters.globalFilterPlaceholder
+        : 'Forage for fruit',
+    }}
+  />
+)
+
+export const ColumnSelectPlaceholder: ComponentStoryFn<typeof DataTable<Fruit>> = ({
+  bannerConfig: filters,
+  ...props
+}) => (
+  <DataTable
+    {...props}
+    data={fruitsData}
+    columns={fruitColumns}
+    bannerConfig={{
+      enableColumnSelect: true,
+      columnSelectPlaceholder: 'Select columns',
       enableGlobalFilterInput: filters?.enableGlobalFilterInput,
       globalFilterPlaceholder: filters?.globalFilterPlaceholder?.length
         ? filters.globalFilterPlaceholder

--- a/packages/apollo-components/src/DataTable/components/ColumnSelect.tsx
+++ b/packages/apollo-components/src/DataTable/components/ColumnSelect.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Divider, Icon, Popover, Tooltip } from '@equinor/eds-core-react'
+import { Button, Checkbox, Divider, Icon, Popover, Tooltip } from "@equinor/eds-core-react";
 import { close, view_column } from '@equinor/eds-icons'
 import { Table } from '@tanstack/react-table'
 import { useRef, useState } from 'react'
@@ -19,26 +19,32 @@ const ActionsWrapper = styled.div`
 `
 
 interface ColumnSelectProps<T> {
-  table: Table<T>
+  table: Table<T>;
+  columnSelectPlaceholder?: string
 }
 
-export function ColumnSelect<T>({ table }: ColumnSelectProps<T>) {
+export function ColumnSelect<T>({ table, columnSelectPlaceholder }: ColumnSelectProps<T>) {
   const [isOpen, setIsOpen] = useState(false)
   const referenceElement = useRef<HTMLButtonElement>(null)
   const selectableColumns = table.getAllLeafColumns().filter((column) => column.id !== 'select')
 
   return (
     <>
-      <Tooltip title="Select columns" placement="left">
+      <Tooltip
+        // empty string internally set to shouldOpen = false.
+        title={columnSelectPlaceholder ? '' : 'Select columns'}
+        placement="left"
+      >
         <Button
           aria-haspopup
           id="column-select-anchor"
           aria-controls="column-select-popover"
           aria-expanded={isOpen}
           ref={referenceElement}
-          variant="ghost_icon"
+          variant={columnSelectPlaceholder ? "ghost" : "ghost_icon"}
           onClick={() => setIsOpen(true)}
         >
+          {columnSelectPlaceholder}
           <Icon name="view_column" data={view_column} />
         </Button>
       </Tooltip>

--- a/packages/apollo-components/src/DataTable/components/DataTableHeader.tsx
+++ b/packages/apollo-components/src/DataTable/components/DataTableHeader.tsx
@@ -56,7 +56,7 @@ export function TableBanner<T>({
               onChange={(value) => globalFilter.onChange(String(value))}
             />
           )}
-          {bannerConfig?.enableColumnSelect && <ColumnSelect table={table} />}
+          {bannerConfig?.enableColumnSelect && <ColumnSelect table={table} columnSelectPlaceholder={bannerConfig.columnSelectPlaceholder} />}
           {bannerConfig?.totalRowCount && (
             <span>
               {table.options.data.length.toLocaleString()} /{' '}

--- a/packages/apollo-components/src/DataTable/types.ts
+++ b/packages/apollo-components/src/DataTable/types.ts
@@ -161,6 +161,7 @@ export interface DataTableProps<T> {
     enableColumnSelect?: boolean
     enableGlobalFilterInput?: boolean
     globalFilterPlaceholder?: string
+    columnSelectPlaceholder?: string
     filterFromLeafRows?: boolean
     /**
      * @deprecated Use `customActionsLeft` instead


### PR DESCRIPTION
## What does this pull request change?
add support for text + icon on button instead of tooltip

## Why is this pull request needed?
new requirement in internal project

## Issues related to this change:
